### PR TITLE
RDK-43928 : Creating mock for Dobbymanager.h dependencies

### DIFF
--- a/unit_tests/L1_testing/CMakeLists.txt
+++ b/unit_tests/L1_testing/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.7)
 project(DobbyL1Test)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
@@ -29,6 +29,7 @@ add_library(Utils SHARED
             ../../utils/source/ContainerId.cpp
             ../../utils/source/DobbyTimer.cpp
             ../../AppInfrastructure/Logging/source/Logging.cpp
+			../../daemon/lib/source/DobbyManager.cpp
             )
 
 target_include_directories(Utils
@@ -37,6 +38,20 @@ target_include_directories(Utils
                 ../../utils/source
                 ../../AppInfrastructure/Logging/include
                 ../../AppInfrastructure/Common/include
+				../../bundle/lib/include
+                ../../ipcUtils/include
+                ../../settings/include
+                ../../daemon/lib/source
+                ../../AppInfrastructure/IpcService/include
+                ../../libocispec/generated_output
+                ../../pluginLauncher/lib/include
+                ../../daemon/lib/include
+                ../../protocol/include
+                ../../build/AppInfrastructure/Tracing
+                ../../rdkPlugins/Networking/include
+                /usr/lib/plugins/dobby
+                /usr/include/jsoncpp
+                mocks
                 )
 
 file(GLOB TESTS tests/*.cpp)

--- a/unit_tests/L1_testing/mocks/DaemonDobbyManagerTest.cpp
+++ b/unit_tests/L1_testing/mocks/DaemonDobbyManagerTest.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+#include "DaemonDobbyManagerTest.h"
+
+class DaemonDobbyManagerTest : public ::testing::Test{
+
+        protected:
+
+};

--- a/unit_tests/L1_testing/mocks/DaemonDobbyManagerTest.h.h
+++ b/unit_tests/L1_testing/mocks/DaemonDobbyManagerTest.h.h
@@ -1,0 +1,26 @@
+#include "DobbyConfigMock.h" 
+
+#include "NetfilterMock.h"
+
+#include "DobbyRootfsMock.h"
+
+#include "DobbyStatsMock.h"
+
+#include "DobbyLoggerMock.h"
+
+#include "DobbyRunCMock.h"
+
+#include "DobbyBundleMock.h"
+
+#include "DobbyContainerMock.h"
+
+#include "DobbyRdkPluginManagerMock.h"
+
+#include "DobbySpecConfigMock.h"
+
+#include "DobbyBundleConfigMock.h"
+
+#include "IpcFileDescriptorMock.h"
+
+#include "DobbyStartStateMock.h"
+

--- a/unit_tests/L1_testing/mocks/DobbyBundleConfigMock.h.h
+++ b/unit_tests/L1_testing/mocks/DobbyBundleConfigMock.h.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "DobbyBundleConfig.h"
+
+class DobbyBundleConfigMock : public DobbyBundleConfig {
+
+public:
+
+    virtual ~DobbyBundleConfigMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD(std::shared_ptr<rt_dobby_schema>, config, (), (const));
+    MOCK_METHOD(bool, restartOnCrash, (), (const));
+
+};
+

--- a/unit_tests/L1_testing/mocks/DobbyBundleMock.h.h
+++ b/unit_tests/L1_testing/mocks/DobbyBundleMock.h.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "DobbyBundle.h"
+
+class DobbyBundleMock : public DobbyBundle {
+
+public:
+
+    virtual ~DobbyBundleMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD(void, setPersistence, (bool persist), ());
+    MOCK_METHOD(bool, isValid, (), (const));
+
+
+};

--- a/unit_tests/L1_testing/mocks/DobbyConfigMock.h.h
+++ b/unit_tests/L1_testing/mocks/DobbyConfigMock.h.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "DobbyConfig.h"
+
+class DobbyConfigMock : public DobbyConfig {
+public:
+    virtual ~DobbyConfigMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD(bool, writeConfigJson, (const std::string& filePath), (const));
+};

--- a/unit_tests/L1_testing/mocks/DobbyContainerMock.h.h
+++ b/unit_tests/L1_testing/mocks/DobbyContainerMock.h.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "DobbyContainer.h"
+
+class DobbyContainerMock : public DobbyContainer {
+
+public:
+
+    virtual ~DobbyContainerMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD(void, setRestartOnCrash, (const std::list<int>& files), ());
+    MOCK_METHOD(void, clearRestartOnCrash, (), ());
+
+};

--- a/unit_tests/L1_testing/mocks/DobbyLoggerMock.h.h
+++ b/unit_tests/L1_testing/mocks/DobbyLoggerMock.h.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "DobbyLogger.h"
+
+class DobbyLoggerMock : public DobbyLogger {
+
+public:
+
+    virtual ~DobbyLoggerMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD(bool, StartContainerLogging, (std::string containerId,
+                               pid_t runtimePid,
+                               pid_t containerPid,
+                               std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin), ());
+};
+

--- a/unit_tests/L1_testing/mocks/DobbyRdkPluginManagerMock.h.h
+++ b/unit_tests/L1_testing/mocks/DobbyRdkPluginManagerMock.h.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "DobbyRdkPluginManager.h"
+
+class DobbyRdkPluginManagerMock : public DobbyRdkPluginManager {
+
+public:
+
+    virtual ~DobbyRdkPluginManagerMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD(const std::vector<std::string>, listLoadedPlugins, (), (const));
+    MOCK_METHOD(std::shared_ptr<IDobbyRdkLoggingPlugin>, getContainerLogger, (), (const));
+};
+

--- a/unit_tests/L1_testing/mocks/DobbyRootfsMock.h.h
+++ b/unit_tests/L1_testing/mocks/DobbyRootfsMock.h.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "DobbyRootfs.h"
+
+class DobbyRootfsMock : public DobbyRootfs {
+
+public:
+
+    virtual ~DobbyRootfsMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD(void, setPersistence, (bool persist), ());
+    MOCK_METHOD(const std::string&, path, (), (const));
+    MOCK_METHOD(bool, isValid, (), (const));
+};
+
+

--- a/unit_tests/L1_testing/mocks/DobbyRunCMock.h.h
+++ b/unit_tests/L1_testing/mocks/DobbyRunCMock.h.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "DobbyRunC.h"
+
+class DobbyRunCMock : public DobbyRunC {
+
+public:
+
+    virtual ~DobbyRunCMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+MOCK_METHOD(bool, killCont, (const ContainerId &id, int signal, bool all), (const));
+MOCK_METHOD(bool, resume, (const ContainerId& id), (const));
+MOCK_METHOD(bool, pause, (const ContainerId& id), (const));
+MOCK_METHOD((std::pair<pid_t, pid_t>), exec, (const ContainerId& id, const std::string& options, const std::string& command), (const));
+};
+

--- a/unit_tests/L1_testing/mocks/DobbySpecConfigMock.h.h
+++ b/unit_tests/L1_testing/mocks/DobbySpecConfigMock.h.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "DobbySpecConfig.h"
+
+class DobbySpecConfigMock : public DobbySpecConfig {
+
+public:
+
+    virtual ~DobbySpecConfigMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD((const std::map<std::string, Json::Value>&), rdkPlugins, (), (const));
+    MOCK_METHOD(const std::string ,spec, (), (const));
+    MOCK_METHOD(bool ,isValid, (), (const));
+    MOCK_METHOD(std::shared_ptr<rt_dobby_schema> ,config, (), (const));
+    MOCK_METHOD(bool ,restartOnCrash, (), (const));
+};

--- a/unit_tests/L1_testing/mocks/DobbyStartStateMock.h.h
+++ b/unit_tests/L1_testing/mocks/DobbyStartStateMock.h.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "DobbyStartState.h"
+
+class DobbyStartStateMock {
+
+public:
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD(std::list<int>, files, (), (const));
+    MOCK_METHOD(bool, isValid, (), (const));
+
+};

--- a/unit_tests/L1_testing/mocks/DobbyStatsMock.h.h
+++ b/unit_tests/L1_testing/mocks/DobbyStatsMock.h.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "DobbyStats.h"
+
+class DobbyStatsMock : public DobbyStats {
+
+public:
+
+    virtual ~DobbyStatsMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD(const Json::Value&, stats, (), (const));
+};
+

--- a/unit_tests/L1_testing/mocks/IpcFileDescriptorMock.h.h
+++ b/unit_tests/L1_testing/mocks/IpcFileDescriptorMock.h.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "IpcFileDescriptor.h"
+
+class IpcFileDescriptorMock : public AI_IPC::IpcFileDescriptor {
+
+public:
+
+    virtual ~IpcFileDescriptorMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD(void, reset, (int fd_), ());
+
+};
+
+
+

--- a/unit_tests/L1_testing/mocks/NetfilterMock.h.h
+++ b/unit_tests/L1_testing/mocks/NetfilterMock.h.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "Netfilter.h"
+
+class NetfilterMock : public Netfilter {
+public:
+    virtual ~NetfilterMock() = default;
+
+    // Declare the mock method using the MOCK_METHOD macro
+    MOCK_METHOD(bool, writeString, (int fd, const std::string &str), (const));
+};
+
+


### PR DESCRIPTION
This change is a sub task  of RDK-43435 : Increase unit (L1) tests coverage for Dobby
